### PR TITLE
Fix disappearing dislikes count

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -787,6 +787,11 @@ static void getVoteFromVideoWithHandler(NSString *videoId, int retryCount, void 
 
 %end
 
+// Disable chips fading animation under player
+%hook YTWatchNextResultsViewController
+- (void)maybeEnableFadingChipsHeaderInCollectionView { }
+%end
+
 static void enableVoteSubmission(BOOL enabled) {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:EnableVoteSubmissionKey];
 }


### PR DESCRIPTION
Disabling fade animation fixes issue described in https://github.com/PoomSmart/Return-YouTube-Dislikes/issues/46